### PR TITLE
给简介添加折叠

### DIFF
--- a/app/src/main/java/blbl/cat3399/feature/video/VideoDetailHeaderAdapter.kt
+++ b/app/src/main/java/blbl/cat3399/feature/video/VideoDetailHeaderAdapter.kt
@@ -258,6 +258,8 @@ class VideoDetailHeaderAdapter(
         private var partsSelectedKey: String? = null
         private var seasonSelectedKey: String? = null
         private var lastTagsKey: String? = null
+        private var isDescExpanded: Boolean = false
+        private var currentDesc: String? = null
 
         private val partsAdapter =
             VideoCardAdapter(
@@ -315,6 +317,11 @@ class VideoDetailHeaderAdapter(
 
             binding.btnPartsOrder.setOnClickListener { onPartsOrderClick() }
             binding.btnSeasonOrder.setOnClickListener { onSeasonOrderClick() }
+
+            binding.tvDesc.setOnClickListener {
+                isDescExpanded = !isDescExpanded
+                updateDescExpandState()
+            }
 
             binding.recyclerParts.layoutManager =
                 LinearLayoutManager(binding.root.context, LinearLayoutManager.HORIZONTAL, false)
@@ -396,6 +403,12 @@ class VideoDetailHeaderAdapter(
 
             val safeDesc = desc?.trim().takeIf { !it.isNullOrBlank() }
             binding.tvDesc.text = safeDesc ?: "暂无简介"
+            
+            // 重置展开状态
+            isDescExpanded = false
+            currentDesc = safeDesc
+            binding.tvDesc.maxLines = 3
+            binding.tvDesc.ellipsize = android.text.TextUtils.TruncateAt.END
 
             bindTags(tags)
 
@@ -594,6 +607,31 @@ class VideoDetailHeaderAdapter(
                 val lm = binding.recyclerSeason.layoutManager as? LinearLayoutManager ?: return@post
                 lm.scrollToPositionWithOffset(0, binding.recyclerSeason.paddingLeft)
             }
+        }
+
+        private fun updateDescExpandState() {
+            if (isDescExpanded) {
+                binding.tvDesc.maxLines = Integer.MAX_VALUE
+                binding.tvDesc.ellipsize = null
+                
+                // 添加动画效果
+                binding.tvDesc.animate()
+                    .setDuration(300)
+                    .alpha(1f)
+                    .start()
+            } else {
+                binding.tvDesc.maxLines = 3
+                binding.tvDesc.ellipsize = android.text.TextUtils.TruncateAt.END
+                
+                // 添加动画效果
+                binding.tvDesc.animate()
+                    .setDuration(300)
+                    .alpha(1f)
+                    .start()
+            }
+            
+            // 请求重新布局
+            binding.root.requestLayout()
         }
 
         private fun cardStableKey(card: VideoCard): String =

--- a/app/src/main/res/layout/item_video_detail_header.xml
+++ b/app/src/main/res/layout/item_video_detail_header.xml
@@ -20,13 +20,15 @@
             android:id="@+id/iv_cover"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:contentDescription="@string/app_name"
             android:background="?attr/colorSurface"
+            android:contentDescription="@string/app_name"
             android:scaleType="centerCrop"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0"
             app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay_Blbl_Rounded" />
 
         <com.google.android.material.imageview.ShapeableImageView
@@ -138,17 +140,28 @@
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
 
-    <TextView
-        android:id="@+id/tv_desc"
+    <LinearLayout
+        android:id="@+id/ll_desc_container"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="12dp"
         android:layout_marginEnd="12dp"
-        android:textColor="?android:attr/textColorSecondary"
-        android:textSize="20sp"
+        android:orientation="vertical"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@id/tv_title"
-        app:layout_constraintTop_toBottomOf="@id/card_up" />
+        app:layout_constraintTop_toBottomOf="@id/card_up">
+
+        <TextView
+            android:id="@+id/tv_desc"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="20sp"
+            android:maxLines="3"
+            android:ellipsize="end"
+            android:clickable="true"
+            android:focusable="true" />
+    </LinearLayout>
 
     <com.google.android.material.chip.ChipGroup
         android:id="@+id/chip_group_tags"
@@ -161,7 +174,7 @@
         app:chipSpacingVertical="10dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@id/tv_title"
-        app:layout_constraintTop_toBottomOf="@id/tv_desc"
+        app:layout_constraintTop_toBottomOf="@id/ll_desc_container"
         app:singleLine="false" />
 
     <com.google.android.material.card.MaterialCardView


### PR DESCRIPTION
给视频详情页简介添加了折叠功能，避免简介过长导致按到分p或推荐视频时的不适。

**原来的效果**
<img width="1920" height="1080" alt="原来" src="https://github.com/user-attachments/assets/4914dfcb-cbab-4f22-8635-a86a253cc526" />
**现在的效果**
<img width="1920" height="1080" alt="之后" src="https://github.com/user-attachments/assets/a7adbdf2-4c7c-49e3-8b9d-38545ac8e8d0" />

代码是DS帮忙写的，我不太懂安卓，看不出有什么明显的问题。

