### PR TITLE
fix crash switching theme

### DIFF
--- a/app/src/main/java/blbl/cat3399/feature/settings/SettingsInteractionHandler.kt
+++ b/app/src/main/java/blbl/cat3399/feature/settings/SettingsInteractionHandler.kt
@@ -36,7 +36,6 @@ import blbl.cat3399.core.prefs.PlayerCustomShortcut
 import blbl.cat3399.core.prefs.PlayerCustomShortcutAction
 import blbl.cat3399.core.prefs.PlayerPlaybackModes
 import blbl.cat3399.core.prefs.PlayerCustomShortcutsStore
-import blbl.cat3399.core.theme.LauncherAliasManager
 import blbl.cat3399.core.ui.AppToast
 import blbl.cat3399.core.ui.Immersive
 import blbl.cat3399.core.ui.popup.AppPopup
@@ -328,7 +327,6 @@ class SettingsInteractionHandler(
                     AppConfigBackup.apply(parsed, prefs = BiliClient.prefs, cookies = BiliClient.cookies)
                 },
             ) {
-                LauncherAliasManager.sync(activity.applicationContext, BiliClient.prefs.themePreset)
                 evictNetworkConnections()
                 AppToast.showLong(activity, if (parsed.includesCredentials) "已导入配置与登录状态，正在重启…" else "已导入配置，正在重启…")
                 restartToMain()
@@ -688,7 +686,6 @@ class SettingsInteractionHandler(
                     }
 
                     prefs.themePreset = key
-                    LauncherAliasManager.sync(activity.applicationContext, key)
                     AppToast.show(activity, "主题：$selected（已应用）")
                     restartToMain()
                 }


### PR DESCRIPTION
> 我来分析这些崩溃日志,寻找主题切换时导致闪退的关键信息。


> 日志中 MIUI Home 报的错：
>   IconLoader: Unexpected null component name or activity info:
>     ComponentInfo{blbl.cat3399.craz/blbl.cat3399.ui.MainLauncherTvPinkAlias}, null
> 
>   这说明 LauncherAliasManager.sync() 在切换 component alias 时，MIUI 的 launcher 检测到了组件状态变化，但拿到的 activity
>    info 是 null。
> 
>   闪退的根因：setComponentEnabledSetting() 虽然传了 DONT_KILL_APP，但在 MIUI 上这个 flag 不一定被尊重。MIUI
>   的系统在检测到 launcher activity-alias 变化时，可能会强制杀掉进程重新解析组件。日志中的 TransitionChain mismatch
>   和随后 app task 从 recents 消失都印证了这一点。
> 
>   时序问题：
>   1. LauncherAliasManager.sync() 禁用旧 alias、启用新 alias
>   2. MIUI 系统检测到变化，杀掉进程
>   3. restartToMain() 还没来得及执行（或刚执行就被杀了）

> 因为 startActivity() 只是入队 intent，sync() 仍然在同一个主线程 tick 里执行。根本问题是：task 的
>   baseIntent 指向 MainLauncherTvPinkAlias，sync() 禁用了这个 alias 后 MIUI 认为 task 无效就杀掉了。
> 
>   换个思路：不在 SettingsInteractionHandler 里调 sync，让新启动的 MainActivity 自己去同步 alias。